### PR TITLE
Make map field not required in bug_report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
     placeholder: |
       Please explicitly state what map the issue occurs on. If this is not a default map, include a download link to the BSP, VMF, or both.
   validations:
-    required: true
+    required: false
 - type: textarea
   attributes:
     label: Expected Behavior


### PR DESCRIPTION
Not all issues are related to the game itself or a map in particular, so I think this field should be optional